### PR TITLE
#7 - Fix double equals typo on <env name="MINK_DRIVER_ARGS_WEBDRIVER">.

### DIFF
--- a/.docksal/settings/phpunit.xml
+++ b/.docksal/settings/phpunit.xml
@@ -36,7 +36,7 @@
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
     <env name="MINK_DRIVER_ARGS" value=''/>
     <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=='["chrome", {"browser": "chrome", "chrome": {"switches":["--disable-gpu", "--headless"]}}, "http://browser:4444/wd/hub"]'/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browser": "chrome", "chrome": {"switches":["--disable-gpu", "--headless"]}}, "http://browser:4444/wd/hub"]'/>
   </php>
   <testsuites>
     <testsuite name="unit">


### PR DESCRIPTION
Resolves #7 